### PR TITLE
Change template placeholder wrappers to gray

### DIFF
--- a/themes/Sorcerer-color-theme.json
+++ b/themes/Sorcerer-color-theme.json
@@ -124,7 +124,9 @@
         "meta.import.ts",
         "meta.import.ts string",
         "meta.import.ts variable",
-        "meta.import.ts meta.block variable.other"
+        "meta.import.ts meta.block variable.other",
+        "punctuation.definition.template-expression.begin",
+        "punctuation.definition.template-expression.end"
       ],
       "settings": {
         "foreground": "#6e7d9a"


### PR DESCRIPTION
In JS and TS (and others like Groovy), the templates have the `${}` pattern that is currently the same color as the string itself, which may make it confusing as to what is part of the string itself and what isn't. This commits tries to fix that.