### PR TITLE
Added menu selection background to fix the highlight issue

### DIFF
--- a/themes/Sorcerer-color-theme.json
+++ b/themes/Sorcerer-color-theme.json
@@ -40,6 +40,7 @@
     "welcomePage.buttonHoverBackground": "#ffffff04",
     "focusBorder": "#ff006a44",
     "menu.border": "#ffffff09",
+    "menu.selectionBackground": "#ffffff15",
     "titleBar.border": "#ffffff09",
     "checkbox.border": "#ffffff09",
     "diffEditor.border": "#ffffff09",

--- a/themes/Sorcerer-color-theme.json
+++ b/themes/Sorcerer-color-theme.json
@@ -68,7 +68,8 @@
     "activityBar.foreground": "#6e7d9a",
     "editorWidget.background": "#0e141a",
     "editorWidget.border": "#ffffff09",
-    "editorSuggestWidget.background": "#0a1016"
+    "editorSuggestWidget.background": "#0a1016",
+    "editorSuggestWidget.selectedBackground": "#ffffff15"
   },
   "tokenColors": [
     {


### PR DESCRIPTION
Fixed the menu highlight issue by adding custom selection background color. Likewise, changed background color in editor suggestion to distinguish the current selection.

Before:
![Before](https://user-images.githubusercontent.com/12433764/130290666-7f3fe4e8-77fd-4f95-ae9c-3034f4736534.png)

After:
![After](https://user-images.githubusercontent.com/12433764/130290689-d9b1d9ed-fee8-4e90-96cc-f8b1ff8a16e8.png)

